### PR TITLE
Update package.json dependencies and README.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,7 +10,7 @@ Example app to show how to use [node-sass](https://github.com/sass/node-sass) as
     cd node-sass-example
     npm install
     node server.js
-    open http://localhost:5000
+    open http://localhost:8000
 
 ## Note on Patches/Pull Requests
 

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   "author": "Andrew Nesbitt",
   "license": "MIT",
   "dependencies": {
-    "connect": "^3.3.4",
-    "node-sass-middleware": "^0.4.0",
-    "serve-static": "^1.8.1"
+    "connect": "^3.4.0",
+    "node-sass-middleware": "^0.9.0",
+    "serve-static": "^1.10.0"
   },
   "engines": {
     "node": ">= 0.10.21"


### PR DESCRIPTION
The outdated node-sass-middleware dependencies was causing `npm install` to fail. This updates all dependencies, node-sass-middleware being the most outdated and the cause of the failed `npm install`.

Old: ^0.4.x
New: ^0.9.x

Also, updates the "port" in the README.md to reflect the actual default port of 8000.
